### PR TITLE
refactor(db): Unificar tablas de inventario

### DIFF
--- a/datos_iniciales.sql
+++ b/datos_iniciales.sql
@@ -85,16 +85,16 @@ INSERT INTO usuarios (nombre_usuario, nombre_completo, email, password_hash, pla
 -- =====================================================
 
 -- Inventario Rancagua
-INSERT INTO inventario_rancagua (title, nombre_material, unidad_medida, cod_nombre, fecha_inventario, pallets, stock, bodega, ubicacion, lote, condicion_armado, contado_por, material_id, ubicacion_id) VALUES
-('BOGR2062', 'BOLSA CE 2,5KG VF FLEX REGINA GENERICA', 'Unidad', 'BOGR2062 - BOLSA CE 2,5KG VF FLEX REGINA GENERICA', CURRENT_DATE, 2, 1000, 'Bodega Principal', 'Altillo Packing', 'LOTE001', 'Normal', 'Sistema', 1, 1),
-('CAJA500', 'CAJA CARTON 500GR CEREZAS', 'Unidad', 'CAJA500 - CAJA CARTON 500GR CEREZAS', CURRENT_DATE, 5, 2500, 'Bodega Exterior', 'Carpa 1', 'LOTE002', 'Normal', 'Sistema', 3, 2),
-('PALL001', 'PALLET MADERA EXPORTACION', 'Unidad', 'PALL001 - PALLET MADERA EXPORTACION', CURRENT_DATE, 0, 50, 'Área Externa', 'Patio Carga', 'LOTE003', 'Normal', 'Sistema', 4, 6);
-
--- Inventario Chimbarongo
-INSERT INTO inventario_chimbarongo (title, nombre_material, unidad_medida, cod_nombre, fecha_inventario, pallets, stock, bodega, ubicacion, lote, condicion_armado, contado_por, material_id, ubicacion_id) VALUES
-('ETIQ001', 'ETIQUETA TRAZABILIDAD LOTE', 'Unidad', 'ETIQ001 - ETIQUETA TRAZABILIDAD LOTE', CURRENT_DATE, 1, 5000, 'Bodega Principal', 'Centro Armado', 'LOTE004', 'Normal', 'Sistema', 2, 9),
-('FILM001', 'FILM PLASTICO PROTECTOR', 'Rollo', 'FILM001 - FILM PLASTICO PROTECTOR', CURRENT_DATE, 1, 20, 'Almacén General', 'Bodega A', 'LOTE005', 'Normal', 'Sistema', 5, 10),
-('KIT001', 'KIT EMBALAJE COMPLETO', 'Kit', 'KIT001 - KIT EMBALAJE COMPLETO', CURRENT_DATE, 3, 100, 'Zona Proceso', 'Área Clasificación', 'LOTE006', 'Armado', 'Sistema', 6, 12);
+-- Inventario Unificado
+INSERT INTO inventario (planta, title, nombre_material, unidad_medida, cod_nombre, fecha_inventario, pallets, stock, bodega, ubicacion, lote, condicion_armado, contado_por, material_id, ubicacion_id) VALUES
+-- Rancagua
+('Rancagua', 'BOGR2062', 'BOLSA CE 2,5KG VF FLEX REGINA GENERICA', 'Unidad', 'BOGR2062 - BOLSA CE 2,5KG VF FLEX REGINA GENERICA', CURRENT_DATE, 2, 1000, 'Bodega Principal', 'Altillo Packing', 'LOTE001', 'Normal', 'Sistema', 1, 1),
+('Rancagua', 'CAJA500', 'CAJA CARTON 500GR CEREZAS', 'Unidad', 'CAJA500 - CAJA CARTON 500GR CEREZAS', CURRENT_DATE, 5, 2500, 'Bodega Exterior', 'Carpa 1', 'LOTE002', 'Normal', 'Sistema', 3, 2),
+('Rancagua', 'PALL001', 'PALLET MADERA EXPORTACION', 'Unidad', 'PALL001 - PALLET MADERA EXPORTACION', CURRENT_DATE, 0, 50, 'Área Externa', 'Patio Carga', 'LOTE003', 'Normal', 'Sistema', 4, 6),
+-- Chimbarongo
+('Chimbarongo', 'ETIQ001', 'ETIQUETA TRAZABILIDAD LOTE', 'Unidad', 'ETIQ001 - ETIQUETA TRAZABILIDAD LOTE', CURRENT_DATE, 1, 5000, 'Bodega Principal', 'Centro Armado', 'LOTE004', 'Normal', 'Sistema', 2, 9),
+('Chimbarongo', 'FILM001', 'FILM PLASTICO PROTECTOR', 'Rollo', 'FILM001 - FILM PLASTICO PROTECTOR', CURRENT_DATE, 1, 20, 'Almacén General', 'Bodega A', 'LOTE005', 'Normal', 'Sistema', 5, 10),
+('Chimbarongo', 'KIT001', 'KIT EMBALAJE COMPLETO', 'Kit', 'KIT001 - KIT EMBALAJE COMPLETO', CURRENT_DATE, 3, 100, 'Zona Proceso', 'Área Clasificación', 'LOTE006', 'Armado', 'Sistema', 6, 12);
 
 -- =====================================================
 -- 8. CONFIGURACIÓN INICIAL DEL SISTEMA
@@ -103,36 +103,19 @@ INSERT INTO inventario_chimbarongo (title, nombre_material, unidad_medida, cod_n
 -- Crear vista para consultas frecuentes de inventario consolidado
 CREATE OR REPLACE VIEW vista_inventario_consolidado AS
 SELECT 
-    'Rancagua' as planta,
-    ir.title,
-    ir.nombre_material,
-    ir.unidad_medida,
-    ir.stock,
-    ir.pallets,
-    ir.bodega,
-    ir.ubicacion,
-    ir.fecha_inventario,
-    ir.lote,
-    ir.condicion_armado
-FROM inventario_rancagua ir
-WHERE ir.stock > 0
-
-UNION ALL
-
-SELECT 
-    'Chimbarongo' as planta,
-    ic.title,
-    ic.nombre_material,
-    ic.unidad_medida,
-    ic.stock,
-    ic.pallets,
-    ic.bodega,
-    ic.ubicacion,
-    ic.fecha_inventario,
-    ic.lote,
-    ic.condicion_armado
-FROM inventario_chimbarongo ic
-WHERE ic.stock > 0;
+    planta,
+    title,
+    nombre_material,
+    unidad_medida,
+    stock,
+    pallets,
+    bodega,
+    ubicacion,
+    fecha_inventario,
+    lote,
+    condicion_armado
+FROM inventario
+WHERE stock > 0;
 
 -- Crear vista para movimientos recientes
 CREATE OR REPLACE VIEW vista_movimientos_recientes AS

--- a/esquema_completo.sql
+++ b/esquema_completo.sql
@@ -123,33 +123,11 @@ CREATE TABLE trazabilidad_materiales_r9 (
 -- =====================================================
 
 -- 2.1 Tabla: inventario_rancagua
--- Descripción: Tabla para llevar registros de inventarios en planta Rancagua
-CREATE TABLE inventario_rancagua (
+-- 2.1 Tabla: inventario
+-- Descripción: Tabla para llevar registros de inventarios en ambas plantas
+CREATE TABLE inventario (
     id SERIAL PRIMARY KEY,
-    title VARCHAR(100) NOT NULL, -- código del material
-    nombre_material VARCHAR(300),
-    unidad_medida VARCHAR(50), -- Unidad, Litros, Rollo, etc.
-    cod_nombre VARCHAR(400),
-    fecha_inventario DATE NOT NULL,
-    pallets INTEGER DEFAULT 0,
-    stock DECIMAL(10,2) NOT NULL,
-    bodega VARCHAR(100),
-    ubicacion VARCHAR(100),
-    lote VARCHAR(100),
-    condicion_armado VARCHAR(50),
-    contado_por VARCHAR(100) NOT NULL,
-    fecha_creacion TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
-    fecha_actualizacion TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
-    
-    -- Claves foráneas
-    material_id INTEGER REFERENCES materiales(id),
-    ubicacion_id INTEGER REFERENCES ubicacion(id)
-);
-
--- 2.2 Tabla: inventario_chimbarongo
--- Descripción: Tabla para llevar registros de inventarios en planta Chimbarongo
-CREATE TABLE inventario_chimbarongo (
-    id SERIAL PRIMARY KEY,
+    planta VARCHAR(50) NOT NULL, -- Rancagua o Chimbarongo
     title VARCHAR(100) NOT NULL, -- código del material
     nombre_material VARCHAR(300),
     unidad_medida VARCHAR(50), -- Unidad, Litros, Rollo, etc.
@@ -239,10 +217,9 @@ CREATE INDEX idx_ubicacion_planta ON ubicacion(planta);
 CREATE INDEX idx_ubicacion_bodega ON ubicacion(bodega_deposito);
 
 -- Índices para inventarios
-CREATE INDEX idx_inventario_rancagua_fecha ON inventario_rancagua(fecha_inventario);
-CREATE INDEX idx_inventario_rancagua_material ON inventario_rancagua(title);
-CREATE INDEX idx_inventario_chimbarongo_fecha ON inventario_chimbarongo(fecha_inventario);
-CREATE INDEX idx_inventario_chimbarongo_material ON inventario_chimbarongo(title);
+CREATE INDEX idx_inventario_fecha ON inventario(fecha_inventario);
+CREATE INDEX idx_inventario_material ON inventario(title);
+CREATE INDEX idx_inventario_planta ON inventario(planta);
 
 -- Índices para usuarios y sesiones
 CREATE INDEX idx_usuarios_nombre_usuario ON usuarios(nombre_usuario);
@@ -287,12 +264,8 @@ CREATE TRIGGER trigger_actualizar_trazabilidad
     BEFORE UPDATE ON trazabilidad_materiales_r9
     FOR EACH ROW EXECUTE FUNCTION actualizar_fecha_modificacion();
 
-CREATE TRIGGER trigger_actualizar_inventario_rancagua
-    BEFORE UPDATE ON inventario_rancagua
-    FOR EACH ROW EXECUTE FUNCTION actualizar_fecha_modificacion();
-
-CREATE TRIGGER trigger_actualizar_inventario_chimbarongo
-    BEFORE UPDATE ON inventario_chimbarongo
+CREATE TRIGGER trigger_actualizar_inventario
+    BEFORE UPDATE ON inventario
     FOR EACH ROW EXECUTE FUNCTION actualizar_fecha_modificacion();
 
 CREATE TRIGGER trigger_actualizar_usuarios
@@ -309,8 +282,7 @@ COMMENT ON TABLE proveedores IS 'Catálogo de proveedores';
 COMMENT ON TABLE temporadas_app IS 'Configuración de temporadas de trabajo';
 COMMENT ON TABLE tipo_movimientos_app IS 'Tipos de movimientos permitidos';
 COMMENT ON TABLE trazabilidad_materiales_r9 IS 'Registro principal de movimientos de materiales';
-COMMENT ON TABLE inventario_rancagua IS 'Inventarios de planta Rancagua';
-COMMENT ON TABLE inventario_chimbarongo IS 'Inventarios de planta Chimbarongo';
+COMMENT ON TABLE inventario IS 'Registros de inventarios de ambas plantas';
 COMMENT ON TABLE usuarios IS 'Usuarios del sistema';
 COMMENT ON TABLE sesiones_usuario IS 'Control de sesiones activas';
 COMMENT ON TABLE logs_sistema IS 'Registro de actividades del sistema';

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -7,9 +7,9 @@ datasource db {
   url      = env("DATABASE_URL")
 }
 
-/// This model or at least one of its fields has comments in the database, and requires an additional setup for migrations: Read more: https://pris.ly/d/database-comments
-model inventario_chimbarongo {
+model inventario {
   id                  Int         @id @default(autoincrement())
+  planta              String      @db.VarChar(50)
   title               String      @db.VarChar(100)
   nombre_material     String?     @db.VarChar(300)
   unidad_medida       String?     @db.VarChar(50)
@@ -29,34 +29,9 @@ model inventario_chimbarongo {
   materiales          materiales? @relation(fields: [material_id], references: [id], onDelete: NoAction, onUpdate: NoAction)
   ubicacion_ref       ubicacion?  @relation(fields: [ubicacion_id], references: [id], onDelete: NoAction, onUpdate: NoAction)
 
-  @@index([fecha_inventario], map: "idx_inventario_chimbarongo_fecha")
-  @@index([title], map: "idx_inventario_chimbarongo_material")
-}
-
-/// This model or at least one of its fields has comments in the database, and requires an additional setup for migrations: Read more: https://pris.ly/d/database-comments
-model inventario_rancagua {
-  id                  Int         @id @default(autoincrement())
-  title               String      @db.VarChar(100)
-  nombre_material     String?     @db.VarChar(300)
-  unidad_medida       String?     @db.VarChar(50)
-  cod_nombre          String?     @db.VarChar(400)
-  fecha_inventario    DateTime    @db.Date
-  pallets             Int?        @default(0)
-  stock               Decimal     @db.Decimal(10, 2)
-  bodega              String?     @db.VarChar(100)
-  ubicacion           String?     @db.VarChar(100)
-  lote                String?     @db.VarChar(100)
-  condicion_armado    String?     @db.VarChar(50)
-  contado_por         String      @db.VarChar(100)
-  fecha_creacion      DateTime?   @default(now()) @db.Timestamp(6)
-  fecha_actualizacion DateTime?   @default(now()) @db.Timestamp(6)
-  material_id         Int?
-  ubicacion_id        Int?
-  materiales          materiales? @relation(fields: [material_id], references: [id], onDelete: NoAction, onUpdate: NoAction)
-  ubicacion_ref       ubicacion?  @relation(fields: [ubicacion_id], references: [id], onDelete: NoAction, onUpdate: NoAction)
-
-  @@index([fecha_inventario], map: "idx_inventario_rancagua_fecha")
-  @@index([title], map: "idx_inventario_rancagua_material")
+  @@index([fecha_inventario], map: "idx_inventario_fecha")
+  @@index([title], map: "idx_inventario_material")
+  @@index([planta], map: "idx_inventario_planta")
 }
 
 /// This model or at least one of its fields has comments in the database, and requires an additional setup for migrations: Read more: https://pris.ly/d/database-comments
@@ -85,8 +60,7 @@ model materiales {
   activo                     Boolean?                     @default(true)
   fecha_creacion             DateTime?                    @default(now()) @db.Timestamp(6)
   fecha_actualizacion        DateTime?                    @default(now()) @db.Timestamp(6)
-  inventario_chimbarongo     inventario_chimbarongo[]
-  inventario_rancagua        inventario_rancagua[]
+  inventario                 inventario[]
   trazabilidad_materiales_r9 trazabilidad_materiales_r9[]
 
   @@index([clasificacion], map: "idx_materiales_clasificacion")
@@ -207,8 +181,7 @@ model ubicacion {
   activo                                                                                Boolean?                     @default(true)
   fecha_creacion                                                                        DateTime?                    @default(now()) @db.Timestamp(6)
   fecha_actualizacion                                                                   DateTime?                    @default(now()) @db.Timestamp(6)
-  inventario_chimbarongo                                                                inventario_chimbarongo[]
-  inventario_rancagua                                                                   inventario_rancagua[]
+  inventario                                                                            inventario[]
   trazabilidad_materiales_r9_trazabilidad_materiales_r9_ubicacion_destino_idToubicacion trazabilidad_materiales_r9[] @relation("trazabilidad_materiales_r9_ubicacion_destino_idToubicacion")
   trazabilidad_materiales_r9_trazabilidad_materiales_r9_ubicacion_origen_idToubicacion  trazabilidad_materiales_r9[] @relation("trazabilidad_materiales_r9_ubicacion_origen_idToubicacion")
 


### PR DESCRIPTION
Refactoriza el esquema de la base de datos para unificar las tablas duplicadas `inventario_rancagua` e `inventario_chimbarongo` en una única tabla `inventario`.

Este cambio aborda la duplicación de código y simplifica la arquitectura de la base de datos, mejorando la mantenibilidad.

- Se ha añadido una columna `planta` a la nueva tabla `inventario` para diferenciar las ubicaciones.
- Se ha actualizado el esquema de Prisma (`schema.prisma`) para reflejar el nuevo modelo.
- Se han modificado los archivos SQL de definición de esquema (`esquema_completo.sql`) y de datos iniciales (`datos_iniciales.sql`) para que sean coherentes con la nueva estructura.